### PR TITLE
Fix textures not loading when `bank` has a two digit value

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -87,8 +87,7 @@ function render(map) {
 }
 
 function loadSprites(bank) {
-    let bankStr = ('0' + bank.toString());
-    bankStr = bankStr.substr(bankStr.length - 2);
+    let bankStr = bank.toString().padStart(2, '0');
 
     globalState.bank = bankStr;
 
@@ -98,8 +97,7 @@ function loadSprites(bank) {
     globalState.images[bankStr] = [];
     for (let i = 0; i <= 0x1f; i++) {
         const img = new Image();
-        let id = ('0' + i.toString());
-        id = id.substr(id.length - 2);
+        let id = i.toString().padStart(2, '0');
         // img.src = 'http://protab./static/img/2017/' + bankStr + '/' + id + '.png';
         img.src = 'img/' + bankStr + '/' + id + '.png';
         let counter = 0;

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -88,7 +88,7 @@ function render(map) {
 
 function loadSprites(bank) {
     const bankStr = ('0' + bank.toString());
-    let = bankStr.substr(bankStr.length - 2);
+    let bankStr = bankStr.substr(bankStr.length - 2);
 
     globalState.bank = bankStr;
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -87,8 +87,8 @@ function render(map) {
 }
 
 function loadSprites(bank) {
-    const bankStr = ('0' + bank.toString());
-    let bankStr = bankStr.substr(bankStr.length - 2);
+    let bankStr = ('0' + bank.toString());
+    bankStr = bankStr.substr(bankStr.length - 2);
 
     globalState.bank = bankStr;
 


### PR DESCRIPTION
Fixed the typo which broke the leftpad = should happen on single digit only like 09 and not 010.

Images were fetched from /img/010/00.png instead of  /img/10/00.png